### PR TITLE
Deprecate `GITHUB_TOKEN` input for `token`

### DIFF
--- a/.github/workflows/title-to-labels.yml
+++ b/.github/workflows/title-to-labels.yml
@@ -15,10 +15,10 @@ jobs:
       - uses: ./
         name: Local action (with defaults)
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: ./
         name: Local action (with inputs)
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           keywords: question, q
           labels: question, documentation

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
     description: The labels to apply when one of the keywords was found. Optional.
   GITHUB_TOKEN:
     description: 'The automatically-generated token, set this to \$\{\{ secrets.GITHUB_TOKEN \}\}'
+    deprecated: Use `token` instead
+  token:
+    description: 'The automatically-generated token, set this to \$\{\{ secrets.GITHUB_TOKEN \}\}'
 runs:
   using: node20
   main: distribution/index.js

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: fregante/title-to-labels-action@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 You can automatically install the above with [ghat](https://github.com/fregante/ghat):
@@ -93,19 +93,20 @@ jobs:
     steps:
       - uses: fregante/title-to-labels-action@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           keywords: idea
           # If you don't specify `labels`, the action will just clean up the titles from your keywords.
 
       # The action can be used as many times as needed in a single job
       - uses: fregante/title-to-labels-action@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           keywords: bug, bug report
           labels: bug
 
       - uses: fregante/title-to-labels-action@v1
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           keywords: |
             feature request
             suggestions

--- a/workflow/labeler.yml
+++ b/workflow/labeler.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: fregante/title-to-labels-action@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Either one will work for now, until the next major 